### PR TITLE
Refactor pan and zoom to work alongside other tools, along with ctrl-…

### DIFF
--- a/tests/controller/test_controller.py
+++ b/tests/controller/test_controller.py
@@ -17,7 +17,8 @@ import numpy as np
 
 from mock import MagicMock, PropertyMock
 
-from friendly_ground_truth.controller.controller import Controller, Mode
+from friendly_ground_truth.controller.controller import (Controller, Mode,
+                                                         SecondaryMode)
 from friendly_ground_truth.view.tk_view import MainWindow
 from friendly_ground_truth.model.model import Patch, Image
 
@@ -71,6 +72,8 @@ class TestController:
         self.mock_C_display_current_patch = mocker.\
             patch.\
             object(Controller, 'display_current_patch')
+
+        return self.mock_C_display_current_patch
 
     @pytest.fixture
     def dialog_mock(self):
@@ -575,14 +578,13 @@ class TestController:
 
         spy.assert_called_once()
 
-    def test_change_mode_zoom(self, setup, mocker,
-                              display_current_patch_mock):
+    def test_change_secondary_mode_zoom(self, setup, mocker,
+                                        display_current_patch_mock):
         """
-        Test changing the mode to zoom
+        Test changing the secondary mode to zoom
 
-        :test_condition: The current mode is set to Mode.ZOOM and
-                         MainWindow.set_brush_radius is called once
-
+        :test_condition: The current secondary mode is set to
+                         SecondaryMode.ZOOM
         :param setup: The setup fixture
         :param mock_brush_radius: A fixture mocking the
                                   MainWindow.set_brush_radius function
@@ -591,7 +593,7 @@ class TestController:
 
         controller = Controller(MagicMock())
         controller.current_mode = Mode.ADD_REGION
-
+        controller.current_secondary_mode = SecondaryMode.ADJUST_TOOL
         mock_patch = MagicMock()
         thresh_mock = PropertyMock(return_value=0.5)
 
@@ -604,13 +606,73 @@ class TestController:
 
         controller.image = mock_image
 
-        spy = mocker.spy(MainWindow, 'set_brush_radius')
+        controller.change_secondary_mode(MainWindow.ID_TOOL_ZOOM)
 
-        controller.change_mode(MainWindow.ID_TOOL_ZOOM)
+        assert controller.current_secondary_mode == SecondaryMode.ZOOM
 
-        spy.assert_called_once()
+    def test_change_secondary_mode_adjust(self, setup, mocker,
+                                          display_current_patch_mock):
+        """
+        Test changing the secondary mode to adjust tool
 
-        assert controller.current_mode == Mode.ZOOM
+        :test_condition: The current secondary mode is set to
+                         SecondaryMode.ADJUST_TOOL
+
+        :param setup: Setup
+        :param mocker: Mocker
+        :param display_current_patch_mock: Mock for display_current_patch
+        :returns: None
+        """
+        controller = Controller(MagicMock())
+        controller.current_mode = Mode.ADD_REGION
+        controller.current_secondary_mode = SecondaryMode.ZOOM
+        mock_patch = MagicMock()
+        thresh_mock = PropertyMock(return_value=0.5)
+
+        type(mock_patch).thresh = thresh_mock
+
+        mock_image = MagicMock()
+        patches_mock = PropertyMock(return_value=[mock_patch])
+
+        type(mock_image).patches = patches_mock
+
+        controller.image = mock_image
+
+        controller.change_secondary_mode(MainWindow.ID_ADJUST_TOOL)
+
+        assert controller.current_secondary_mode == SecondaryMode.ADJUST_TOOL
+
+    def test_change_secondary_mode_invalid(self, setup, mocker,
+                                           display_current_patch_mock):
+        """
+        Test changing the secondary mode to adjust tool
+
+        :test_condition: The current secondary mode is set to
+                         SecondaryMode.ADJUST_TOOL
+
+        :param setup: Setup
+        :param mocker: Mocker
+        :param display_current_patch_mock: Mock for display_current_patch
+        :returns: None
+        """
+        controller = Controller(MagicMock())
+        controller.current_mode = Mode.ADD_REGION
+        controller.current_secondary_mode = SecondaryMode.ZOOM
+        mock_patch = MagicMock()
+        thresh_mock = PropertyMock(return_value=0.5)
+
+        type(mock_patch).thresh = thresh_mock
+
+        mock_image = MagicMock()
+        patches_mock = PropertyMock(return_value=[mock_patch])
+
+        type(mock_image).patches = patches_mock
+
+        controller.image = mock_image
+
+        controller.change_secondary_mode(MainWindow.ID_TOOL_ADD_TIP)
+
+        assert controller.current_secondary_mode == SecondaryMode.ZOOM
 
     def test_change_mode_flood_add(self, setup, mocker,
                                    display_current_patch_mock):
@@ -862,6 +924,7 @@ class TestController:
 
         controller = Controller(MagicMock())
         controller.current_mode = Mode.THRESHOLD
+        controller.current_secondary_mode = SecondaryMode.ADJUST_TOOL
 
         mock_patch = MagicMock()
         thresh_mock = PropertyMock(return_value=0.5)
@@ -897,6 +960,7 @@ class TestController:
 
         controller = Controller(MagicMock())
         controller.current_mode = Mode.ADD_REGION
+        controller.current_secondary_mode = SecondaryMode.ADJUST_TOOL
 
         spy = mocker.spy(controller, 'adjust_add_region_brush')
 
@@ -920,6 +984,7 @@ class TestController:
 
         controller = Controller(MagicMock())
         controller.current_mode = Mode.REMOVE_REGION
+        controller.current_secondary_mode = SecondaryMode.ADJUST_TOOL
 
         spy = mocker.spy(controller, 'adjust_remove_region_brush')
 
@@ -941,7 +1006,8 @@ class TestController:
         """
 
         controller = Controller(MagicMock())
-        controller.current_mode = Mode.ZOOM
+        controller.current_mode = Mode.THRESHOLD
+        controller.current_secondary_mode = SecondaryMode.ZOOM
         controller.main_window = MagicMock()
         controller.main_window.image_scale = 1
         controller.main_window.MAX_SCALE = 16
@@ -980,6 +1046,7 @@ class TestController:
 
         controller = Controller(MagicMock())
         controller.current_mode = Mode.FLOOD_ADD
+        controller.current_secondary_mode = SecondaryMode.ADJUST_TOOL
         controller.flood_add_position = (0, 0)
 
         mock_patch = MagicMock()
@@ -1014,6 +1081,7 @@ class TestController:
 
         controller = Controller(MagicMock())
         controller.current_mode = Mode.FLOOD_REMOVE
+        controller.current_secondary_mode = SecondaryMode.ADJUST_TOOL
         controller.flood_remove_position = (0, 0)
 
         mock_patch = MagicMock()
@@ -1048,6 +1116,7 @@ class TestController:
         """
 
         controller = Controller(MagicMock())
+        controller.current_secondary_mode = SecondaryMode.ADJUST_TOOL
         controller.current_mode = Mode.REMOVE_LANDMARK
 
         spy = mocker.spy(controller, 'adjust_remove_landmark_brush')
@@ -1071,7 +1140,26 @@ class TestController:
 
         controller = Controller(MagicMock())
         controller.current_mode = Mode.NO_ROOT
+        controller.current_secondary_mode = Mode.NO_ROOT
+        result = controller.handle_mouse_wheel(-1, 0, 0)
 
+        assert False is result
+
+    def test_handle_mouse_wheel_invalid_adjust(self, setup,
+                                               display_current_patch_mock):
+        """
+        Test when the mouse wheel function is called and the current mode is
+        invalid and SecondaryMode.ADJUST_TOOL
+
+        :test_condition: The function returns False
+
+        :param setup: The setup fixture
+        :returns: None
+        """
+
+        controller = Controller(MagicMock())
+        controller.current_mode = Mode.NO_ROOT
+        controller.current_secondary_mode = SecondaryMode.ADJUST_TOOL
         result = controller.handle_mouse_wheel(-1, 0, 0)
 
         assert False is result
@@ -1622,32 +1710,6 @@ class TestController:
         result = controller.handle_left_click((10, -10))
         assert False is result
 
-    def test_handle_right_click_zoom(self, setup, display_current_patch_mock):
-        """
-        Test when a right click happens while zooming
-
-        :test_condition: The main_window.image_scale is set to 1, and the
-                         main_window.image_x and image_y are set to 0
-
-        :param setup: Setup
-        :param display_current_patch_mock: Mock for displaying the current
-                                           patch
-        :returns: None
-        """
-
-        controller = Controller(MagicMock())
-        controller.current_mode = Mode.ZOOM
-        controller.main_window = MagicMock()
-        controller.main_window.image_scale = 10
-        controller.main_window.image_x = 10
-        controller.main_window.image_y = 10
-
-        controller.handle_right_click()
-
-        assert controller.main_window.image_scale == 1
-        assert controller.main_window.image_x == 0
-        assert controller.main_window.image_y == 0
-
     def test_handle_right_click_other(self, setup, display_current_patch_mock):
         """
         Test when a right click happens while not zooming
@@ -1710,26 +1772,6 @@ class TestController:
         result = controller.handle_left_release()
 
         assert True is result
-
-    def test_handle_left_release_zoom(self, setup, mocker,
-                                      display_current_patch_mock):
-        """
-        Test when the mouse is released and the current mode is Mode.ZOOM
-
-        :test_condition:  display_current_patch() is called and the function
-                          returns True
-
-        :param setup: The setup fixture
-        :returns: None
-        """
-
-        controller = Controller(MagicMock())
-        controller.current_mode = Mode.ZOOM
-
-        result = controller.handle_left_release()
-
-        assert True is result
-        self.mock_C_display_current_patch.assert_called_once()
 
     def test_handle_left_release_invalid_mode(self, setup,
                                               display_current_patch_mock):
@@ -1825,18 +1867,21 @@ class TestController:
         mock_patch.remove_region.assert_called_with(position, radius)
         assert True is result
 
-    def test_handle_motion_zoom(self, setup, display_current_patch_mock):
+    def test_handle_mouse_wheel_motion_zoom(self, setup,
+                                            display_current_patch_mock):
         """
-        Test when the mouse is moved and the current mode is Mode.ZOOM
+        Test when the mouse is moved and the current secondary mode is
+        SecondaryMode.ZOOM
 
-        :test_condition: Returns True
+        :test_condition: controller.display_current_patch is called
 
         :param setup: The setip fixture
         :returns: None
         """
 
         controller = Controller(MagicMock())
-        controller.current_mode = Mode.ZOOM
+        controller.current_mode = Mode.THRESHOLD
+        controller.current_secondary_mode = SecondaryMode.ZOOM
         controller.main_window = MagicMock()
         controller.main_window.image_scale = 1
         controller.main_window.image_x = 0
@@ -1853,9 +1898,9 @@ class TestController:
 
         position = (1, 2)
 
-        result = controller.handle_motion(position)
+        controller.handle_mouse_wheel_motion(position)
 
-        assert True is result
+        display_current_patch_mock.assert_called()
 
     def test_handle_motion_remove_landmark(self, setup,
                                            display_current_patch_mock):
@@ -2537,3 +2582,34 @@ class TestController:
 
         controller.show_saved_preview()
         show_patch.assert_called()
+
+    def test_handle_mouse_wheel_motion_adjust(self, setup,
+                                              display_current_patch_mock):
+        """
+        Test when the mouse is moved with the mouse wheel clicked in
+
+        :test_condition: display_current_patch is not called
+
+        :param setup: Setup
+        :param display_current_patch_mock: Mock for the display current patch
+                                           function
+        :returns: None
+        """
+        controller = Controller(MagicMock())
+        controller.current_mode = Mode.THRESHOLD
+        controller.current_secondary_mode = SecondaryMode.ADJUST_TOOL
+
+        mock_patch = MagicMock()
+        thresh_mock = PropertyMock(return_value=0.5)
+
+        type(mock_patch).thresh = thresh_mock
+
+        mock_image = MagicMock()
+        patches_mock = PropertyMock(return_value=[mock_patch])
+
+        type(mock_image).patches = patches_mock
+
+        controller.image = mock_image
+
+        controller.handle_mouse_wheel_motion((0, 0))
+        display_current_patch_mock.assert_not_called()

--- a/tests/view/test_view.py
+++ b/tests/view/test_view.py
@@ -232,6 +232,7 @@ class TestView():
         window = MainWindow(self.mock_controller, MagicMock())
 
         event = MagicMock()
+        event.state = 0
 
         spy = mocker.spy(window, 'on_next_tool')
 
@@ -254,6 +255,7 @@ class TestView():
 
         event = MagicMock()
         event.char = 'x'
+        event.state = 0
 
         spy = mocker.spy(window, 'on_no_root_tool')
 
@@ -276,29 +278,9 @@ class TestView():
 
         event = MagicMock()
         event.char = 't'
+        event.state = 0
 
         spy = mocker.spy(window, 'on_threshold_tool')
-
-        window.on_keypress(event)
-
-        spy.assert_called()
-
-    def test_on_keypress_z(self, setup, mocker):
-        """
-        Test when the z key is pressed
-
-        :test_condition: on_zoom_tool() is called
-
-        :param setup: Setup fixture
-        :param mocker: mocker
-        :returns: None
-        """
-        window = MainWindow(self.mock_controller, MagicMock())
-
-        event = MagicMock()
-        event.char = 'z'
-
-        spy = mocker.spy(window, 'on_zoom_tool')
 
         window.on_keypress(event)
 
@@ -319,6 +301,7 @@ class TestView():
 
         event = MagicMock()
         event.char = 'a'
+        event.state = 0
 
         spy = mocker.spy(window, 'on_add_reg_tool')
 
@@ -340,6 +323,7 @@ class TestView():
 
         event = MagicMock()
         event.char = 'r'
+        event.state = 0
 
         spy = mocker.spy(window, 'on_remove_reg_tool')
 
@@ -362,6 +346,7 @@ class TestView():
 
         event = MagicMock()
         event.char = 'f'
+        event.state = 0
 
         spy = mocker.spy(window, 'on_flood_add_tool')
 
@@ -384,6 +369,7 @@ class TestView():
 
         event = MagicMock()
         event.char = 'l'
+        event.state = 0
 
         spy = mocker.spy(window, 'on_flood_remove_tool')
 
@@ -406,6 +392,7 @@ class TestView():
 
         event = MagicMock()
         event.char = 'c'
+        event.state = 0
 
         spy = mocker.spy(window, 'on_add_cross_tool')
 
@@ -428,6 +415,7 @@ class TestView():
 
         event = MagicMock()
         event.char = 'v'
+        event.state = 0
 
         spy = mocker.spy(window, 'on_add_tip_tool')
 
@@ -450,6 +438,7 @@ class TestView():
 
         event = MagicMock()
         event.char = 'b'
+        event.state = 0
 
         spy = mocker.spy(window, 'on_add_branch_tool')
 
@@ -472,6 +461,7 @@ class TestView():
 
         event = MagicMock()
         event.char = 'n'
+        event.state = 0
 
         spy = mocker.spy(window, 'on_remove_landmark_tool')
 
@@ -713,23 +703,6 @@ class TestView():
         self.mock_controller.change_mode\
                             .assert_called_with(window.ID_TOOL_NO_ROOT)
 
-    def test_on_zoom_tool(self, setup, mocker):
-        """
-        Test when the zoom tool is chosen
-
-        :test_condition: controller.change_mode is called with ID_TOOL_ZOOM
-
-        :param setup: setup
-        :param mocker: mocker
-        :returns: None
-        """
-
-        window = MainWindow(self.mock_controller, MagicMock())
-        window.on_zoom_tool()
-
-        self.mock_controller.change_mode\
-                            .assert_called_with(window.ID_TOOL_ZOOM)
-
     def test_on_flood_add_tool(self, setup, mocker):
         """
         Test when the flood add region tool is chosen
@@ -823,6 +796,32 @@ class TestView():
                                                                    event.x,
                                                                    event.y)
 
+    def test_on_click_release(self, setup, mocker):
+        """
+        Test when the left mouse click is released
+
+        :test_condition: on_enter_canvas is called
+
+        :param setup: Setup
+        :param mocker: Mocker
+        :returns: None
+        """
+
+        window = MainWindow(self.mock_controller, MagicMock())
+
+        window.on_enter_canvas = MagicMock()
+
+        event = MagicMock()
+        event.num = 0
+        event.delta = 120
+        event.x = 0
+        event.y = 10
+        event.state = 0x8
+
+        window.on_click_release(event)
+
+        window.on_enter_canvas.assert_called()
+
     def test_on_mousewheel_5(self, setup, mocker):
         """
         Test when the mousewheel is used and event.num is 5 and event.delta is
@@ -867,12 +866,110 @@ class TestView():
         event.delta = 120
         event.x = 0
         event.y = 10
-
+        event.state = 0x5
         window.on_mousewheel(event)
 
         self.mock_controller.handle_mouse_wheel.assert_called_with(120,
                                                                    event.x,
                                                                    event.y)
+
+    def test_on_mousewheel_alt(self, setup, mocker):
+        """
+        Test the mousewheel when alt is pressed
+
+        :test_condition: change_secondary_mode is called
+        :param setup: Setup
+        :param mocker: Mocker
+        :returns: None
+        """
+        window = MainWindow(self.mock_controller, MagicMock())
+
+        event = MagicMock()
+        event.num = 0
+        event.delta = 120
+        event.x = 0
+        event.y = 10
+        event.state = 0x8
+
+        window.on_mousewheel(event)
+
+        self.mock_controller.change_secondary_mode\
+            .assert_called()
+
+    def test_on_wheel_release(self, setup, mocker):
+        """
+        Test when the mouse wheel is released
+
+        :test_condition: on_enter_canvas is called
+
+        :param setup: Setup
+        :param mocker: Mocker
+        :returns: None
+        """
+        window = MainWindow(self.mock_controller, MagicMock())
+
+        event = MagicMock()
+        event.num = 0
+        event.delta = 120
+        event.x = 0
+        event.y = 10
+        event.state = 0x8
+
+        window.on_enter_canvas = MagicMock()
+
+        window.on_wheel_release(event)
+
+        window.on_enter_canvas.assert_called()
+
+    def test_on_wheel_click(self, setup, mocker):
+        """
+        Test when the mouse wheel is clicked
+
+        :test_condition: Canvas.config is called and previous position is
+                         set to the event position
+
+        :param setup: Setup
+        :param mocker: Mocker
+        :returns: None
+        """
+        canvas_mock = mocker.patch('tkinter.Canvas.config')
+
+        window = MainWindow(self.mock_controller, MagicMock())
+
+        event = MagicMock()
+        event.num = 0
+        event.delta = 120
+        event.x = 0
+        event.y = 10
+        event.state = 0x8
+
+        window.on_wheel_click(event)
+
+        canvas_mock.assert_called()
+
+        assert window.previous_position == (event.x, event.y)
+
+    def test_on_wheel_motion(self, setup, mocker):
+        """
+        Test when the mouse is moved with the wheel depressed
+
+        :test_condition: handle_mouse_wheel_motion is called
+
+        :returns: None
+        """
+        window = MainWindow(self.mock_controller, MagicMock())
+
+        event = MagicMock()
+        event.num = 0
+        event.delta = 120
+        event.x = 0
+        event.y = 10
+        event.state = 0x8
+
+        window.on_wheel_motion(event)
+
+        self.mock_controller.handle_mouse_wheel_motion\
+            .assert_called()
 
     def test_on_drag(self, setup, mocker):
         """
@@ -884,12 +981,35 @@ class TestView():
         :param mocker: mocker
         :returns: None
         """
-
+        mocker.patch('tkinter.Canvas.config')
         window = MainWindow(self.mock_controller, MagicMock())
 
-        window.on_drag(MagicMock())
+        event = MagicMock()
+        event.state = 0
+
+        window.on_drag(event)
 
         self.mock_controller.handle_motion.assert_called()
+
+    def test_on_drag_ctrl(self, setup, mocker):
+        """
+        Test when the mouse is dragged with ctrl pressed
+
+        :test_condition: controller.handle_mouse_wheel_motion is called
+
+        :param setup: Setup
+        :param mocker: Mocker
+        :returns: None
+        """
+        mocker.patch('tkinter.Canvas.config')
+        window = MainWindow(self.mock_controller, MagicMock())
+
+        event = MagicMock()
+        event.state = 0x4
+
+        window.on_drag(event)
+
+        self.mock_controller.handle_mouse_wheel_motion.assert_called()
 
     def test_on_motion_not_zoom(self, setup, mocker):
         """


### PR DESCRIPTION
Fixes #102

## Proposed Changes

  - Removal of Zoom Tool
  - Zooming can now be done while using any tool, via the mouse wheel.  Panning can also be done at any time by clicking the mouse wheel (or ctrl-clicking) and dragging the mouse.
