### PR TITLE
Redo gray

### DIFF
--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased] - <>
 ### Added 
 - Updated keyboard shortcuts dialog to reflect all usable shortcuts
+- Undo button becomes disabled if there are no un-doable actions
 
 ## [v0.7.2] - 2020-05-06
 ### Changed

--- a/doc/changelog.txt
+++ b/doc/changelog.txt
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased] - <>
 ### Added 
 - Updated keyboard shortcuts dialog to reflect all usable shortcuts
-- Undo button becomes disabled if there are no un-doable actions
+- Redo button becomes disabled if there are no re-doable actions
 
 ## [v0.7.2] - 2020-05-06
 ### Changed

--- a/friendly_ground_truth/controller/controller.py
+++ b/friendly_ground_truth/controller/controller.py
@@ -1057,6 +1057,8 @@ class Controller:
             return
 
         self.undo_manager.add_to_redo_stack(patch, operation)
+        self.main_window.toolbar_buttons[self.main_window.ID_TOOL_REDO]\
+            .config(state="normal")
 
         self.image.patches[self.current_patch] = redo_patch
 
@@ -1072,6 +1074,9 @@ class Controller:
             return
 
         self.undo_manager.add_to_undo_stack(patch, operation)
+        if len(self.undo_manager.redo_stack) == 0:
+            self.main_window.toolbar_buttons[self.main_window.ID_TOOL_REDO]\
+                .config(state="disabled")
 
         self.image.patches[self.current_patch] = undo_patch
 

--- a/friendly_ground_truth/view/tk_view.py
+++ b/friendly_ground_truth/view/tk_view.py
@@ -67,6 +67,8 @@ class MainWindow(Frame):
     ID_TOOL_ADD_BRANCH = 112
     ID_TOOL_REMOVE_LANDMARK = 113
     ID_ADJUST_TOOL = 114
+    ID_TOOL_UNDO = 115
+    ID_TOOL_REDO = 116
 
     MAX_SCALE = 16
     MIN_SCALE = 0.25
@@ -360,6 +362,7 @@ class MainWindow(Frame):
                                 command=self.controller.redo)
         redo_button.image = redo_img
         redo_button.pack(side=LEFT, padx=2, pady=2)
+        redo_button.config(state="disabled")
 
         CreateToolTip(redo_button, "Redo (CTRL+R)")
 
@@ -447,6 +450,8 @@ class MainWindow(Frame):
         # self.toolbar_buttons[self.ID_TOOL_ADD_BRANCH] = add_branch_button
         # self.toolbar_buttons[self.ID_TOOL_REMOVE_LANDMARK] = \
         #    remove_landmark_button
+        self.toolbar_buttons[self.ID_TOOL_UNDO] = undo_button
+        self.toolbar_buttons[self.ID_TOOL_REDO] = redo_button
 
         self.image_indicator = tk.Label(self.toolbar, text="No Image Loaded")
         self.image_indicator.pack(side=RIGHT, padx=2, pady=2)

--- a/tests/controller/test_controller.py
+++ b/tests/controller/test_controller.py
@@ -2994,7 +2994,9 @@ class TestController:
         """
         master = MagicMock()
         controller = Controller(master)
-
+        controller.main_window.toolbar_buttons = {controller.
+                                                  main_window.ID_TOOL_REDO:
+                                                  MagicMock()}
         controller.current_patch = 0
 
         mock_patch = MagicMock()
@@ -3038,7 +3040,9 @@ class TestController:
         controller = Controller(master)
 
         controller.current_patch = 0
-
+        controller.main_window.toolbar_buttons = {controller.
+                                                  main_window.ID_TOOL_REDO:
+                                                  MagicMock()}
         mock_patch = MagicMock()
         mock_patch.overlay_image = np.ones((10, 10, 3), dtype=np.uint8)
         mock_patch.patch_index = (2, 2)
@@ -3065,6 +3069,40 @@ class TestController:
         undo_manager.redo.assert_called()
         undo_manager.add_to_undo_stack.assert_called_with(mock_patch, 'test')
         assert controller.image.patches[0] == mock_patch2
+
+    def test_disable_redo_button(self, setup, mocker,
+                                 display_current_patch_mock):
+
+        master = MagicMock()
+        controller = Controller(master)
+
+        controller.current_patch = 0
+        controller.main_window.toolbar_buttons = {controller.
+                                                  main_window.ID_TOOL_REDO:
+                                                  MagicMock()}
+        mock_patch = MagicMock()
+        mock_patch.overlay_image = np.ones((10, 10, 3), dtype=np.uint8)
+        mock_patch.patch_index = (2, 2)
+
+        mock_patch2 = MagicMock()
+        mock_patch2.overlay_image = np.ones((10, 10, 3), dtype=np.uint8)
+        mock_patch2.patch_index = (2, 2)
+
+        mock_image = MagicMock()
+        mock_image.NUM_PATCHES = 3
+        patches_mock = PropertyMock(return_value=[mock_patch])
+
+        type(mock_image).patches = patches_mock
+
+        controller.image = mock_image
+
+        spy = mocker.spy(controller.undo_manager, 'redo')
+
+        controller.undo_manager.redo_stack = [(MagicMock(), "test"),
+                                              (MagicMock(), "test")]
+
+        controller.redo()
+        spy.assert_called()
 
     def test_undo_none(self, setup, display_current_patch_mock):
         """


### PR DESCRIPTION
Fixes #157 

## Proposed Changes

  - Redo button becomes grayed out when there is nothing to re-do
