### PR TITLE
Flood tools now retain their settings accross patches

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -4,9 +4,13 @@ This file keeps a record of important changes to the project.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - <>
+### Added
 - Improved Pan and Zoom Performance
 - Auto centering of current patch when moving to the next patch
+
+### Changed
 - No Root Tool now automatically moves to the next patch
+- Flood tools now retain their settings across patches
 
 ## [v0.7.7] - 2020-05-09
 ### ADDED

--- a/friendly_ground_truth/controller/tools.py
+++ b/friendly_ground_truth/controller/tools.py
@@ -891,7 +891,6 @@ class FloodAddTool(FGTTool):
     @patch.setter
     def patch(self, patch):
         self._patch = patch
-        self._tolerance = 0.05
         self._prev_position = None
 
     def on_click(self, position):
@@ -1047,7 +1046,6 @@ class FloodRemoveTool(FGTTool):
     @patch.setter
     def patch(self, patch):
         self._patch = patch
-        self._tolerance = 0.05
         self._prev_position = None
 
     def on_click(self, position):


### PR DESCRIPTION
Fixes #190

## Proposed Changes

  - Flood tools keep their settings across patches.