### PR TITLE
Fix brush stroke undos

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -4,6 +4,9 @@ This file keeps a record of important changes to the project.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased - <>
+### Changed
+- Brush strokes are now detected separately, meaning the undo operation won't
+undo everything you have done anymore.
 
 ## [v0.9.1] - 2020-05-27
 ### Changed

--- a/friendly_ground_truth/controller/controller.py
+++ b/friendly_ground_truth/controller/controller.py
@@ -366,12 +366,13 @@ class Controller():
         if not self._undo_manager.undo_empty:
             self._main_window.enable_button(self._undo_id)
 
-    def drag_event(self, pos):
+    def drag_event(self, pos, drag_id=None):
         """
         A click event in the main window has occured/
 
         Args:
             pos: The position of the event.
+            drag_id: Unique identifier for the drag event.
 
         Returns:
             None
@@ -383,7 +384,7 @@ class Controller():
         # skimage
         pos = round(pos[1]-1), round(pos[0]-1)
 
-        self._current_tool.on_drag(pos)
+        self._current_tool.on_drag(pos, drag_id=drag_id)
 
         if not self._undo_manager.undo_empty:
             self._main_window.enable_button(self._undo_id)

--- a/friendly_ground_truth/controller/tools.py
+++ b/friendly_ground_truth/controller/tools.py
@@ -211,12 +211,13 @@ class FGTTool():
         """
         pass
 
-    def on_drag(self, position):
+    def on_drag(self, position, drag_id=None):
         """
         What happens for click and drag.
 
         Args:
             position: The position of the mouse
+            drag_id: Unique identifier for drag events.
 
         Returns:
             None
@@ -475,6 +476,9 @@ class AddRegionTool(FGTTool):
         self._brush_observers = []
         self._brush_sizer = None
 
+        # To distinguish different brush strokes in the undo stack
+        self._drag_id = 0
+
     @property
     def brush_radius(self):
         return self._brush_radius
@@ -586,18 +590,25 @@ class AddRegionTool(FGTTool):
 
         self._draw(position)
 
-    def on_drag(self, position):
+    def on_drag(self, position, drag_id=None):
         """
         What to do when clicking and dragging
 
         Args:
             position: The position of the mouse.
+            drag_id: Unique identifier for drag events.
 
         Returns:
             None
         """
+
+        tag = "add_region_adjust"
+
+        if drag_id is not None:
+            tag += "_" + str(drag_id)
+
         self._undo_manager.add_to_undo_stack(copy.deepcopy(self.patch),
-                                             "add_region_adjust")
+                                             tag)
 
         t = threading.Thread(target=self._draw, name="draw", args=(position, ))
         t.daemon = True
@@ -753,18 +764,24 @@ class RemoveRegionTool(FGTTool):
 
         self._draw(position)
 
-    def on_drag(self, position):
+    def on_drag(self, position, drag_id=None):
         """
         What to do when clicking and dragging
 
         Args:
             position: The position of the mouse.
+            drag_id: Unique identifier for drag events.
 
         Returns:
             None
         """
+        tag = "remove_region_adjust"
+
+        if drag_id is not None:
+            tag += "_" + str(drag_id)
+
         self._undo_manager.add_to_undo_stack(copy.deepcopy(self.patch),
-                                             "remove_region_adjust")
+                                             tag)
 
         t = threading.Thread(target=self._draw, name="draw", args=(position, ))
         t.daemon = True

--- a/friendly_ground_truth/view/fgt_canvas.py
+++ b/friendly_ground_truth/view/fgt_canvas.py
@@ -60,6 +60,8 @@ class FGTCanvas:
         self._coord_scale = 1
         self._dragged = False
         self._prev_offset = (0, 0)
+        self._drag_id = ''
+        self._unique_drag_id = 0
 
         self._style = style
 
@@ -677,13 +679,22 @@ class FGTCanvas:
             self.canvas.scan_dragto(event.x, event.y, gain=1)
 
         if self._cursor == "brush":
+
+            if self._drag_id == '':
+                self._logger.debug("Drag start")
+            else:
+                self._main_window._master.after_cancel(self._drag_id)
+
+            self._drag_id = self._main_window._master.\
+                after(100, self._stop_dragging)
+
             pos = self.canvas.canvasx(event.x), self.canvas.canvasy(event.y)
             self._previous_position = pos
             container_coords = self.canvas.coords(self.container)
             pos = pos[0] - container_coords[0], pos[1] - container_coords[1]
             pos = pos[0] / self._coord_scale, pos[1] / self._coord_scale
 
-            self._main_window.on_canvas_drag(pos)
+            self._main_window.on_canvas_drag(pos, drag_id=self._unique_drag_id)
 
             brush_pos = (self.canvas.canvasx(event.x),
                          self.canvas.canvasy(event.y))
@@ -691,6 +702,10 @@ class FGTCanvas:
             self.draw_brush(brush_pos)
 
         self.__show_image()  # zoom tile and show it on the canvas
+
+    def _stop_dragging(self):
+        self._drag_id = ''
+        self._unique_drag_id += 1
 
     def _right_drag(self, event):
         """

--- a/friendly_ground_truth/view/main_window.py
+++ b/friendly_ground_truth/view/main_window.py
@@ -280,18 +280,18 @@ class MainWindow(ttk.Frame):
         """
         self._controller.click_event(pos)
 
-    def on_canvas_drag(self, pos):
+    def on_canvas_drag(self, pos, drag_id=None):
         """
         Called when the canvas has a drag event.
 
         Args:
             pos: The position of the drag.
-
+            drag_id: Idenitifier for unique drag events.
 
         Returns:
             None
         """
-        self._controller.drag_event(pos)
+        self._controller.drag_event(pos, drag_id=drag_id)
 
     def set_canvas_cursor(self, cursor):
         """

--- a/tests/unit_tests/controller/test_controller.py
+++ b/tests/unit_tests/controller/test_controller.py
@@ -203,6 +203,39 @@ class TestIo(TestController):
         assert controller._image is not None
         dcp_mock.assert_called()
 
+    def test_load_new_image_none_file(self, setup, dcp_mock,
+                                      valid_rgb_image_path,
+                                      controller, mocker):
+        """
+        Test loading a new image when the user cancels and no image path is
+        returned.
+
+        Args:
+            setup: Setup for testing.
+            dcp_mock: mock for the display_display_current_patch function.
+            valid_rgb_image_path: A path to a valid RGB image.
+            controller: The controller object to test with.
+            mocker: The mocker interface.
+
+        Test Condition:
+            _image_path is none
+            _image is none
+            _display_current_patch is not called
+        """
+        mock_file = mocker.patch('tkinter.filedialog.askopenfilename')
+        mock_file.return_value = None
+
+        mocker.patch("friendly_ground_truth.view.main_window.MainWindow"
+                     ".start_progressbar")
+        mocker.patch("friendly_ground_truth.controller.controller.Controller."
+                     "_update_progressbar")
+
+        controller.load_new_image()
+
+        assert controller._image_path is None
+        assert controller._image is None
+        assert not dcp_mock.called
+
 
 class TestInteractions(TestController):
     """


### PR DESCRIPTION
Fixes #216

## Proposed Changes

  - Drag start and stop are now tracked with IDs to allow distinguishing between different drags.
